### PR TITLE
feat: Highlight theme for using the TabLine highlight groups

### DIFF
--- a/lua/bufbar/themes/highlight.lua
+++ b/lua/bufbar/themes/highlight.lua
@@ -1,0 +1,38 @@
+-- Gets the colors for the given highlight group, and formats them for bufbar.
+local function highlight(group)
+  local gui  = vim.api.nvim_get_hl_by_name(group, true)
+  local term = vim.api.nvim_get_hl_by_name(group, false)
+  return {
+    guifg   = string.format("#%06x", gui.foreground),
+    guibg   = string.format("#%06x", gui.background),
+    ctermfg = string.format("%d",    term.foreground),
+    ctermbg = string.format("%d",    term.background)
+  }
+end
+
+-- Follow the tabline highlight groups.
+return {
+  separator = {
+    normal     = highlight('TabLineFill'),
+    emphasized = highlight('StatusLine')
+  },
+  listed = {
+    inactive   = highlight('TabLine'),
+    active     = highlight('TabLineSel'),
+    active_low = highlight('TabLineSel'),
+  },
+  modified = {
+    inactive   = highlight('TabLine'),
+    active     = highlight('TabLineSel'),
+    active_low = highlight('TabLineSel'),
+  },
+  terminal = {
+    inactive   = highlight('TabLine'),
+    active     = highlight('TabLineSel'),
+    active_low = highlight('TabLineSel'),
+  },
+  tabs = {
+    inactive   = highlight('TabLine'),
+    active     = highlight('TabLineSel'),
+  },
+}


### PR DESCRIPTION
I wrote a theme which pulls the colors from the TabLine highlight groups and uses those.

It might also be useful as a template, if other people want to make a theme based on highlight groups.